### PR TITLE
escape all angle brackets in markdown form

### DIFF
--- a/src/routes/write_a_story_post.js
+++ b/src/routes/write_a_story_post.js
@@ -11,7 +11,8 @@ module.exports = {
       date_posted: Date.now()
     });
 
-    marked(req.payload.body_text, (err, content) => {
+    const strippedText = req.payload.body_text.replace(/<|>/g, match => match === '<' ? '&lt;' : '&gt;');
+    marked(strippedText, (err, content) => {
       newArticle.body_text = content;
 
       post.articles(newArticle, (dbErr) => {

--- a/src/routes/write_a_story_prev_post.js
+++ b/src/routes/write_a_story_prev_post.js
@@ -4,7 +4,8 @@ module.exports = {
   method: 'POST',
   path: '/write-a-story-preview',
   handler: (req, reply) => {
-    marked(req.payload.body_text, (err, markdown) => {
+    const strippedText = req.payload.body_text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    marked(strippedText, (err, markdown) => {
       req.payload.body_text = markdown;
 
       reply(req.payload);


### PR DESCRIPTION
 Previously scripts could be inserted by including <script> tags in the markdown

relates to #18